### PR TITLE
bug/better_branch extraction

### DIFF
--- a/examples/appstores_sync.py
+++ b/examples/appstores_sync.py
@@ -1,11 +1,11 @@
 from ovos_skills_manager import Pling, MycroftMarketplace, AndloSkillList, \
     OVOSstore, NeonSkills
 
-appstore = Pling(parse_github=True)
+appstore = Pling(parse_github=False)
 appstore.sync_skills_list(new_only=False)
 total_skills = appstore.total_skills()
 print(total_skills)
-# 53
+# 70
 
 appstore = OVOSstore(parse_github=True)
 appstore.sync_skills_list(new_only=False)

--- a/ovos_skills_manager/github/__init__.py
+++ b/ovos_skills_manager/github/__init__.py
@@ -125,7 +125,7 @@ def get_branch(url):
 
 def get_branch_from_github_releases(url, branch=None):
     try:
-        return get_branch_from_skill_json_github_api(url, branch)
+        return get_branch_from_latest_release_github_api(url)
     except GithubAPIRateLimited:
         return get_branch_from_latest_release_github_url(url)
 

--- a/ovos_skills_manager/github/api.py
+++ b/ovos_skills_manager/github/api.py
@@ -136,6 +136,15 @@ def get_latest_release_from_api(url, branch=None):
     return get_repo_releases_from_github_api(url)[0]
 
 
+def get_branch_from_latest_release_github_api(url, branch=None):
+    try:
+        return get_latest_release_from_api(url)["name"]
+    except IndexError:
+        raise GithubInvalidBranch(f"no releases for {url}")
+    except Exception as e:
+        raise GithubAPIRateLimited
+
+
 def get_file_from_github_api(url, filepath, branch=None):
     author, repo = author_repo_from_github_url(url)
     branch = branch or get_branch_from_github_api(url)

--- a/ovos_skills_manager/github/raw.py
+++ b/ovos_skills_manager/github/raw.py
@@ -475,9 +475,15 @@ def get_branch_from_skill_json_github_url(url):
 
 
 def get_branch_from_latest_release_github_url(url):
-    # let's assume latest release
-    try:
-        release = get_repo_releases_from_github_url(url)[0]
-        return release["name"]
-    except:
-        raise GithubFileNotFound
+    final_url = get_latest_release_github_url(url)
+    return get_branch_from_github_url(final_url)
+
+
+def get_latest_release_github_url(url):
+    url = normalize_github_url(url)
+    url += "/releases/latest"
+    final_url = requests.get(url).url
+    if final_url.endswith("/releases"):
+        raise GithubInvalidBranch(f"no releases for {url}")
+    return final_url
+

--- a/ovos_skills_manager/github/utils.py
+++ b/ovos_skills_manager/github/utils.py
@@ -98,6 +98,8 @@ def get_branch_from_github_url(url, validate=False):
         branch = url.split("/tree/")[-1].split("/")[0]
     if "/commit/" in url:
         branch = url.split("/commit/")[-1].split("/")[0]
+    if "/tag/" in url:
+        branch = url.split("/tag/")[-1].split("/")[0]
 
     if branch:
         if validate:

--- a/test/test_github_utils.py
+++ b/test/test_github_utils.py
@@ -37,6 +37,18 @@ class TestGithubUrlParsing(unittest.TestCase):
             GithubInvalidBranch, get_branch_from_github_url, normie
         )
 
+        normie = "https://github.com/JarbasSkills/skill-dagon"
+        # implicit tag in url
+        self.assertEqual(
+            get_branch_from_github_url(normie + "/releases/tag/v0.4.0"),
+            "v0.4.0"
+        )
+        # implicit commit in url
+        self.assertEqual(
+            get_branch_from_github_url(normie + "/commit/1cdb0b9d2f2cc855dae281f719da0a0833d29cad"),
+            "1cdb0b9d2f2cc855dae281f719da0a0833d29cad"
+        )
+
     def test_author_repo_from_url(self):
         url = "https://github.com/JarbasSkills/skill-wolfie"
         self.assertEqual(author_repo_from_github_url(url),
@@ -87,7 +99,7 @@ class TestGithubUrlParsing(unittest.TestCase):
         self.assertEqual(download_url_from_github_url(url, branch=branch), dl)
 
 
-# NOTE bellow make actual http requests
+# NOTE below make actual http requests
 class TestGithubUrlValidation(unittest.TestCase):
 
     def test_branch(self):


### PR DESCRIPTION

- support urls with release tags
- new util to get latest github release from url
- fix use `get_branch_from_latest_release_github_api` (was using mistakenly using branch_from_json)

authored-by: jarbasai <jarbasai@mailfence.com>