### PR TITLE
Add method to install skill via URL without SkillEntry/Appstore parsing

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,3 +46,7 @@ jobs:
       - name: Test Search Skill
         run: |
           pytest tests/test_search_skill.py
+
+      - name: Test OSM
+        run: |
+          pytest tests/test_osm.py

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,29 +24,43 @@ jobs:
           pip install pytest pytest-timeout pytest-cov
 
       - name: Test Github Branch Parsing
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           pytest tests/test_github_branch_parsing.py
 
       - name: Test Github Utils
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           pytest tests/test_github_utils.py
 
       - name: Test License Parsing
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           pytest tests/test_licenses.py
 
       - name: Test Skill Entry
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           pytest tests/test_skill_entry.py
 
       - name: Test Utils
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           pytest tests/test_utils.py
 
       - name: Test Search Skill
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           pytest tests/test_search_skill.py
 
       - name: Test OSM
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           pytest tests/test_osm.py

--- a/ovos_skills_manager/exceptions.py
+++ b/ovos_skills_manager/exceptions.py
@@ -91,3 +91,7 @@ class GithubAPIRepoNotFound(GithubAPIException):
 
 class GithubAPIRateLimited(GithubAPIException):
     """ API rate limit exceeded """
+
+
+class GithubHTTPRateLimited(GithubInvalidUrl):
+    """ HTTP Abuse Detection rate limit"""

--- a/ovos_skills_manager/github/__init__.py
+++ b/ovos_skills_manager/github/__init__.py
@@ -45,8 +45,10 @@ def get_skill_data(url, branch=None):
         data["authorname"] = api_data["owner"]["login"]
         if "license" in data:
             data["license"] = api_data["license"]["key"]
-    except:
+    except GithubAPIException:
         pass
+    except Exception as e:
+        LOG.error(e)
 
     # augment with releases data
     try:

--- a/ovos_skills_manager/github/__init__.py
+++ b/ovos_skills_manager/github/__init__.py
@@ -206,7 +206,7 @@ def get_requirements_json(url, branch=None):
         manif = get_manifest(url, branch)
         data = manif['dependencies'] or {}
     except GithubSkillEntryError:
-        pass
+        LOG.error("Error reading from manifest!")
     data["python"] = data.get("python") or []
     data["skill"] = data.get("skill") or []
     data["system"] = data.get("system") or {}
@@ -214,12 +214,12 @@ def get_requirements_json(url, branch=None):
         req = get_requirements(url, branch)
         data["python"] = list(set(data["python"] + req))
     except GithubSkillEntryError:
-        pass
+        LOG.error("Error reading from requirements files!")
     try:
         skill_req = get_skill_requirements(url, branch)
         data["skill"] = list(set(data["skill"] + skill_req))
     except GithubSkillEntryError:
-        pass
+        LOG.error("Error reading skills requirements!")
     return data
 
 

--- a/ovos_skills_manager/github/api.py
+++ b/ovos_skills_manager/github/api.py
@@ -49,6 +49,7 @@ def api_zip_url_from_github_url(url, branch=None, token=None):
 
     raise GithubInvalidUrl
 
+
 # Github API methods
 def get_repo_data_from_github_api(url, branch=None):
     author, repo = author_repo_from_github_url(url)

--- a/ovos_skills_manager/github/raw.py
+++ b/ovos_skills_manager/github/raw.py
@@ -37,10 +37,14 @@ GITHUB_ANDROID_JSON_LOCATIONS = [
 
 
 def get_main_branch_from_github_url(url):
-    url = normalize_github_url(url)
-    html = requests.get(url).text
-    encoded = html.split("default-branch=\"")[1].split('"')[0]
-    return base64.b64decode(encoded).decode("utf-8")
+    try:
+        url = normalize_github_url(url)
+        html = requests.get(url).text
+        encoded = html.split("default-branch=\"")[1].split('"')[0]
+        return base64.b64decode(encoded).decode("utf-8")
+    except Exception as e:
+        LOG.error(e)
+        raise GithubInvalidUrl
 
 
 def get_repo_releases_from_github_url(url):

--- a/ovos_skills_manager/github/raw.py
+++ b/ovos_skills_manager/github/raw.py
@@ -41,6 +41,8 @@ def get_main_branch_from_github_url(url):
     try:
         url = normalize_github_url(url)
         html = requests.get(url).text
+        if "<title>Rate limit &middot; GitHub</title>" in html:
+            raise GithubHTTPRateLimited
         encoded = html.split("default-branch=\"")[1].split('"')[0]
         return base64.b64decode(encoded).decode("utf-8")
     except Exception as e:
@@ -54,6 +56,8 @@ def get_repo_releases_from_github_url(url):
     normalized_giturl = normalize_github_url(url)
     url = GithubUrls.TAGS.format(author=author, repo=repo)
     html = requests.get(url).text
+    if "<title>Rate limit &middot; GitHub</title>" in html:
+        raise GithubHTTPRateLimited
     soup = bs4.BeautifulSoup(html, 'html.parser')
     urls = ["https://github.com" + a['href'] for a in soup.find_all('a')
             if a['href'].startswith("/" + author)]
@@ -201,14 +205,21 @@ def manifest_url_from_github_url(url, branch=None):
 def get_requirements_from_github_url(url, branch=None):
     branch = branch or get_branch_from_github_url(url)
     url = requirements_url_from_github_url(url, branch)
-    return [t for t in requests.get(url).text.split("\n")
+    html = requests.get(url).text
+    if "<title>Rate limit &middot; GitHub</title>" in html:
+        raise GithubHTTPRateLimited
+
+    return [t for t in html.split("\n")
             if t.strip() and not t.strip().startswith("#")]
 
 
 def get_skill_requirements_from_github_url(url, branch=None):
     branch = branch or get_branch_from_github_url(url)
     url = skill_requirements_url_from_github_url(url, branch)
-    return [t for t in requests.get(url).text.split("\n")
+    html = requests.get(url).text
+    if "<title>Rate limit &middot; GitHub</title>" in html:
+        raise GithubHTTPRateLimited
+    return [t for t in html.split("\n")
             if t.strip() and not t.strip().startswith("#")]
 
 
@@ -216,6 +227,8 @@ def get_manifest_from_github_url(url, branch=None):
     branch = branch or get_branch_from_github_url(url)
     url = manifest_url_from_github_url(url, branch)
     manifest = requests.get(url).text
+    if "<title>Rate limit &middot; GitHub</title>" in manifest:
+        raise GithubHTTPRateLimited
     data = yaml.safe_load(manifest)
     if not data:
         # most likely just the template full of comments
@@ -251,6 +264,8 @@ def get_skill_json_from_github_url(url, branch=None):
         raise GithubFileNotFound
     try:
         res = requests.get(url).text
+        if "<title>Rate limit &middot; GitHub</title>" in res:
+            raise GithubHTTPRateLimited
         return json.loads(res)
     except:
         # this might happen if branch is considered valid

--- a/ovos_skills_manager/github/raw.py
+++ b/ovos_skills_manager/github/raw.py
@@ -37,12 +37,14 @@ GITHUB_ANDROID_JSON_LOCATIONS = [
 
 
 def get_main_branch_from_github_url(url):
+    html = None
     try:
         url = normalize_github_url(url)
         html = requests.get(url).text
         encoded = html.split("default-branch=\"")[1].split('"')[0]
         return base64.b64decode(encoded).decode("utf-8")
     except Exception as e:
+        LOG.error(f"html={html}")
         LOG.error(e)
         raise GithubInvalidUrl
 

--- a/ovos_skills_manager/github/raw.py
+++ b/ovos_skills_manager/github/raw.py
@@ -234,7 +234,10 @@ def get_manifest_from_github_url(url, branch=None):
 
 
 def get_skill_json_from_github_url(url, branch=None):
-    branch = branch or get_branch_from_github_url(url)
+    try:
+        branch = branch or get_branch_from_github_url(url)
+    except GithubInvalidBranch:
+        branch = get_main_branch_from_github_url(url)
     try:
         url = get_json_url_from_github_url(url, branch)
         url = blob2raw(url)

--- a/ovos_skills_manager/github/utils.py
+++ b/ovos_skills_manager/github/utils.py
@@ -1,10 +1,6 @@
-from ovos_utils.json_helper import merge_dict
-
 from ovos_skills_manager.exceptions import *
-from ovos_utils import camel_case_split
-
-
 from ovos_skills_manager.session import SESSION as requests
+from ovos_utils import camel_case_split
 from enum import Enum
 
 

--- a/ovos_skills_manager/github/utils.py
+++ b/ovos_skills_manager/github/utils.py
@@ -169,24 +169,3 @@ def match_url_template(url, template, branch=None):
         return blob2raw(url)
     raise GithubInvalidUrl
 
-
-def get_skill_entry_from_url(url: str):
-    from ovos_skills_manager.github import get_branch_from_github_url, normalize_github_url, get_requirements_json, \
-        get_skill_json
-    from ovos_skills_manager.skill_entry import SkillEntry
-    try:
-        branch = get_branch_from_github_url(url)
-    except GithubInvalidBranch:
-        branch = None
-    url = normalize_github_url(url)
-    requirements = get_requirements_json(url, branch)
-    requirements["system"] = {k: v.split() for k, v in requirements.get("system", {}).items()}
-    try:
-        json = get_skill_json(url, branch)
-        requirements = merge_dict(requirements, json.get("requirements", {}),
-                                  merge_lists=True, skip_empty=True, no_dupes=True)
-    except GithubFileNotFound:
-        pass
-    return SkillEntry.from_json({"url": url,
-                                 "branch": branch,
-                                 "requirements": requirements}, False)

--- a/ovos_skills_manager/github/utils.py
+++ b/ovos_skills_manager/github/utils.py
@@ -162,6 +162,8 @@ def match_url_template(url, template, branch=None):
     author, repo = author_repo_from_github_url(url)
     url = template.format(author=author, branch=branch, repo=repo)
     if requests.get(url).status_code == 200:
+        if "<title>Rate limit &middot; GitHub</title>" in requests.get(url).text:
+            raise GithubHTTPRateLimited
         return blob2raw(url)
     raise GithubInvalidUrl
 

--- a/ovos_skills_manager/osm.py
+++ b/ovos_skills_manager/osm.py
@@ -277,7 +277,7 @@ class OVOSSkillsManager:
         try:
             branch = get_branch_from_github_url(url)
         except GithubInvalidBranch:
-            branch = None  # get_main_branch(url)
+            branch = None
         url = normalize_github_url(url)
         requirements = get_requirements_json(url, branch)
         requirements["system"] = {k: v.split() for k, v in requirements.get("system", {}).items()}

--- a/ovos_skills_manager/osm.py
+++ b/ovos_skills_manager/osm.py
@@ -295,8 +295,7 @@ class OVOSSkillsManager:
         Installs a Skill from the passed url
         :param url: Git url of skill to install (including optional branch spec)
         """
-        skill_entry = self.skill_entry_from_url(url)
-        self.install_skill(skill_entry)
+        self.install_skill(self.skill_entry_from_url(url))
 
     def install_skill(self, skill: SkillEntry):
         """

--- a/ovos_skills_manager/osm.py
+++ b/ovos_skills_manager/osm.py
@@ -270,13 +270,14 @@ class OVOSSkillsManager:
         :param url:
         :return:
         """
+        from ovos_skills_manager.exceptions import GithubInvalidBranch, GithubFileNotFound
         from ovos_skills_manager.github import get_branch_from_github_url, normalize_github_url, get_requirements_json,\
-            get_skill_json, get_main_branch, GithubInvalidBranch, GithubFileNotFound
+            get_skill_json
         from ovos_skills_manager.skill_entry import SkillEntry
         try:
             branch = get_branch_from_github_url(url)
         except GithubInvalidBranch:
-            branch = get_main_branch(url)
+            branch = None  # get_main_branch(url)
         url = normalize_github_url(url)
         requirements = get_requirements_json(url, branch)
         requirements["system"] = {k: v.split() for k, v in requirements.get("system", {}).items()}

--- a/ovos_skills_manager/osm.py
+++ b/ovos_skills_manager/osm.py
@@ -270,13 +270,13 @@ class OVOSSkillsManager:
         :param url:
         :return:
         """
-        from ovos_skills_manager.github import get_branch_from_github_url, normalize_github_url, get_requirements_json, \
-            get_skill_json, GithubInvalidBranch, GithubFileNotFound
+        from ovos_skills_manager.github import get_branch_from_github_url, normalize_github_url, get_requirements_json,\
+            get_skill_json, get_main_branch, GithubInvalidBranch, GithubFileNotFound
         from ovos_skills_manager.skill_entry import SkillEntry
         try:
             branch = get_branch_from_github_url(url)
         except GithubInvalidBranch:
-            branch = None
+            branch = get_main_branch()
         url = normalize_github_url(url)
         requirements = get_requirements_json(url, branch)
         requirements["system"] = {k: v.split() for k, v in requirements.get("system", {}).items()}

--- a/ovos_skills_manager/osm.py
+++ b/ovos_skills_manager/osm.py
@@ -276,7 +276,7 @@ class OVOSSkillsManager:
         try:
             branch = get_branch_from_github_url(url)
         except GithubInvalidBranch:
-            branch = get_main_branch()
+            branch = get_main_branch(url)
         url = normalize_github_url(url)
         requirements = get_requirements_json(url, branch)
         requirements["system"] = {k: v.split() for k, v in requirements.get("system", {}).items()}

--- a/ovos_skills_manager/osm.py
+++ b/ovos_skills_manager/osm.py
@@ -1,6 +1,8 @@
 from ovos_utils.log import LOG
 from ovos_utils.json_helper import merge_dict
 from json_database import JsonStorageXDG
+
+from ovos_skills_manager import SkillEntry
 from ovos_skills_manager.appstores.andlo import AndloSkillList
 from ovos_skills_manager.appstores.mycroft_marketplace import \
     MycroftMarketplace
@@ -261,7 +263,16 @@ class OVOSSkillsManager:
                 yield skill
             store.clear_authentication()
 
-    def install_skill(self, skill):
+    def install_skill_from_url(self, url: str):
+        """
+        Installs a Skill from the passed url
+        :param url: Git url of skill to install (including optional branch spec)
+        """
+        from ovos_skills_manager.github import get_skill_entry_from_url
+        skill_entry = get_skill_entry_from_url(url)
+        self.install_skill(skill_entry)
+
+    def install_skill(self, skill: SkillEntry):
         """
         Installs a SkillEntry with any required auth_token
         """

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -2,10 +2,10 @@ import os
 import sys
 import unittest
 
-from ovos_skills_manager.github import get_main_branch_from_github_url
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from ovos_skills_manager.github.utils import *
+from ovos_skills_manager.github import get_main_branch_from_github_url
 
 # TODO setup a test skill repo, since a random url can simply vanish
 

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -107,46 +107,6 @@ class TestGithubUtils(unittest.TestCase):
         branch = "v0.1.0"
         self.assertEqual(download_url_from_github_url(url, branch=branch), dl)
 
-    def test_get_skill_entry_from_url_default_branch(self):
-        from ovos_skills_manager import SkillEntry
-
-        skill_entry = get_skill_entry_from_url("https://github.com/NeonDaniel/skill-osm-test")
-        self.assertIsInstance(skill_entry, SkillEntry)
-        self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
-        self.assertIsInstance(skill_entry.requirements["python"], list)
-        self.assertIsInstance(skill_entry.requirements["system"], dict)
-        self.assertIsInstance(skill_entry.requirements["skill"], list)
-        self.assertIsInstance(skill_entry.download_url, str)
-        self.assertTrue(skill_entry.download_url.endswith("/main.zip"))
-
-    def test_get_skill_entry_from_url_no_json(self):
-        from ovos_skills_manager import SkillEntry
-
-        skill_entry = get_skill_entry_from_url("https://github.com/NeonDaniel/skill-osm-test/tree/no_json")
-        self.assertIsInstance(skill_entry, SkillEntry)
-        self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
-        self.assertEqual(skill_entry.branch, "no_json")
-        self.assertIsInstance(skill_entry.requirements["python"], list)
-        self.assertIsInstance(skill_entry.requirements["system"], dict)
-        self.assertIsInstance(skill_entry.requirements["skill"], list)
-        self.assertIsInstance(skill_entry.download_url, str)
-        self.assertTrue(skill_entry.download_url.endswith("/no_json.zip"))
-
-    def test_get_skill_entry_from_url_release(self):
-        from ovos_skills_manager import SkillEntry
-
-        skill_entry = get_skill_entry_from_url("https://github.com/NeonDaniel/skill-osm-test@v0.1.1")
-        self.assertIsInstance(skill_entry, SkillEntry)
-        self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
-        self.assertEqual(skill_entry.branch, "v0.1.1")
-        self.assertIsInstance(skill_entry.requirements["python"], list)
-        self.assertEqual(set(skill_entry.requirements["python"]),
-                         {"json-requirements", "manifest_requirement", "text_requirements"})
-        self.assertIsInstance(skill_entry.requirements["system"], dict)
-        self.assertIsInstance(skill_entry.requirements["skill"], list)
-        self.assertIsInstance(skill_entry.download_url, str)
-        self.assertTrue(skill_entry.download_url.endswith("/v0.1.1.zip"))
-
 
 # NOTE below make actual http requests
 class TestGithubUrlValidation(unittest.TestCase):

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -2,6 +2,8 @@ import os
 import sys
 import unittest
 
+from ovos_skills_manager.github import get_main_branch_from_github_url
+
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from ovos_skills_manager.github.utils import *
 
@@ -57,6 +59,10 @@ class TestGithubUtils(unittest.TestCase):
             get_branch_from_github_url(normie + "@dev"),
             "dev"
         )
+
+    def test_get_main_branch_from_github_url(self):
+        branch = get_main_branch_from_github_url("https://github.com/NeonDaniel/skill-osm-test")
+        self.assertEqual(branch, "main")
 
     def test_author_repo_from_url(self):
         url = "https://github.com/JarbasSkills/skill-wolfie"

--- a/tests/test_github_utils.py
+++ b/tests/test_github_utils.py
@@ -107,6 +107,46 @@ class TestGithubUtils(unittest.TestCase):
         branch = "v0.1.0"
         self.assertEqual(download_url_from_github_url(url, branch=branch), dl)
 
+    def test_get_skill_entry_from_url_default_branch(self):
+        from ovos_skills_manager import SkillEntry
+
+        skill_entry = get_skill_entry_from_url("https://github.com/NeonDaniel/skill-osm-test")
+        self.assertIsInstance(skill_entry, SkillEntry)
+        self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
+        self.assertIsInstance(skill_entry.requirements["python"], list)
+        self.assertIsInstance(skill_entry.requirements["system"], dict)
+        self.assertIsInstance(skill_entry.requirements["skill"], list)
+        self.assertIsInstance(skill_entry.download_url, str)
+        self.assertTrue(skill_entry.download_url.endswith("/main.zip"))
+
+    def test_get_skill_entry_from_url_no_json(self):
+        from ovos_skills_manager import SkillEntry
+
+        skill_entry = get_skill_entry_from_url("https://github.com/NeonDaniel/skill-osm-test/tree/no_json")
+        self.assertIsInstance(skill_entry, SkillEntry)
+        self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
+        self.assertEqual(skill_entry.branch, "no_json")
+        self.assertIsInstance(skill_entry.requirements["python"], list)
+        self.assertIsInstance(skill_entry.requirements["system"], dict)
+        self.assertIsInstance(skill_entry.requirements["skill"], list)
+        self.assertIsInstance(skill_entry.download_url, str)
+        self.assertTrue(skill_entry.download_url.endswith("/no_json.zip"))
+
+    def test_get_skill_entry_from_url_release(self):
+        from ovos_skills_manager import SkillEntry
+
+        skill_entry = get_skill_entry_from_url("https://github.com/NeonDaniel/skill-osm-test@v0.1.1")
+        self.assertIsInstance(skill_entry, SkillEntry)
+        self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
+        self.assertEqual(skill_entry.branch, "v0.1.1")
+        self.assertIsInstance(skill_entry.requirements["python"], list)
+        self.assertEqual(set(skill_entry.requirements["python"]),
+                         {"json-requirements", "manifest_requirement", "text_requirements"})
+        self.assertIsInstance(skill_entry.requirements["system"], dict)
+        self.assertIsInstance(skill_entry.requirements["skill"], list)
+        self.assertIsInstance(skill_entry.download_url, str)
+        self.assertTrue(skill_entry.download_url.endswith("/v0.1.1.zip"))
+
 
 # NOTE below make actual http requests
 class TestGithubUrlValidation(unittest.TestCase):

--- a/tests/test_osm.py
+++ b/tests/test_osm.py
@@ -4,11 +4,16 @@ import unittest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 from ovos_skills_manager.osm import OVOSSkillsManager
-
+from ovos_skills_manager.session import set_github_token
 osm = OVOSSkillsManager()
 
 
 class TestOvosSkillsManager(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        github_token = os.environ.get("GITHUB_TOKEN")
+        if github_token:
+            set_github_token(github_token)
 
     def test_get_skill_entry_from_url_default_branch(self):
         from ovos_skills_manager import SkillEntry

--- a/tests/test_osm.py
+++ b/tests/test_osm.py
@@ -44,7 +44,8 @@ class TestOvosSkillsManager(unittest.TestCase):
         self.assertEqual(skill_entry.branch, "v0.1.1")
         self.assertIsInstance(skill_entry.requirements["python"], list)
         self.assertEqual(set(skill_entry.requirements["python"]),
-                         {"json-requirements", "manifest_requirement", "text_requirements"})
+                         {"json-requirements", "manifest_requirement", "text_requirements"},
+                         repr(set(skill_entry.requirements["python"])))
         self.assertIsInstance(skill_entry.requirements["system"], dict)
         self.assertIsInstance(skill_entry.requirements["skill"], list)
         self.assertIsInstance(skill_entry.download_url, str)

--- a/tests/test_osm.py
+++ b/tests/test_osm.py
@@ -30,8 +30,11 @@ class TestOvosSkillsManager(unittest.TestCase):
         self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
         self.assertEqual(skill_entry.branch, "no_json")
         self.assertIsInstance(skill_entry.requirements["python"], list)
+        self.assertTrue(len(skill_entry.requirements["python"]) > 0)
         self.assertIsInstance(skill_entry.requirements["system"], dict)
+        self.assertTrue(len(skill_entry.requirements["system"].keys()) > 0)
         self.assertIsInstance(skill_entry.requirements["skill"], list)
+        self.assertTrue(len(skill_entry.requirements["skill"]) > 0)
         self.assertIsInstance(skill_entry.download_url, str)
         self.assertTrue(skill_entry.download_url.endswith("/no_json.zip"))
 

--- a/tests/test_osm.py
+++ b/tests/test_osm.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from ovos_skills_manager.osm import OVOSSkillsManager
+
+osm = OVOSSkillsManager()
+
+
+class TestOvosSkillsManager(unittest.TestCase):
+
+    def test_get_skill_entry_from_url_default_branch(self):
+        from ovos_skills_manager import SkillEntry
+
+        skill_entry = osm.skill_entry_from_url("https://github.com/NeonDaniel/skill-osm-test")
+        self.assertIsInstance(skill_entry, SkillEntry)
+        self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
+        self.assertIsInstance(skill_entry.requirements["python"], list)
+        self.assertIsInstance(skill_entry.requirements["system"], dict)
+        self.assertIsInstance(skill_entry.requirements["skill"], list)
+        self.assertIsInstance(skill_entry.download_url, str)
+        self.assertTrue(skill_entry.download_url.endswith("/main.zip"))
+
+    def test_get_skill_entry_from_url_no_json(self):
+        from ovos_skills_manager import SkillEntry
+
+        skill_entry = osm.skill_entry_from_url("https://github.com/NeonDaniel/skill-osm-test/tree/no_json")
+        self.assertIsInstance(skill_entry, SkillEntry)
+        self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
+        self.assertEqual(skill_entry.branch, "no_json")
+        self.assertIsInstance(skill_entry.requirements["python"], list)
+        self.assertIsInstance(skill_entry.requirements["system"], dict)
+        self.assertIsInstance(skill_entry.requirements["skill"], list)
+        self.assertIsInstance(skill_entry.download_url, str)
+        self.assertTrue(skill_entry.download_url.endswith("/no_json.zip"))
+
+    def test_get_skill_entry_from_url_release(self):
+        from ovos_skills_manager import SkillEntry
+
+        skill_entry = osm.skill_entry_from_url("https://github.com/NeonDaniel/skill-osm-test@v0.1.1")
+        self.assertIsInstance(skill_entry, SkillEntry)
+        self.assertEqual(skill_entry.url, "https://github.com/NeonDaniel/skill-osm-test")
+        self.assertEqual(skill_entry.branch, "v0.1.1")
+        self.assertIsInstance(skill_entry.requirements["python"], list)
+        self.assertEqual(set(skill_entry.requirements["python"]),
+                         {"json-requirements", "manifest_requirement", "text_requirements"})
+        self.assertIsInstance(skill_entry.requirements["system"], dict)
+        self.assertIsInstance(skill_entry.requirements["skill"], list)
+        self.assertIsInstance(skill_entry.download_url, str)
+        self.assertTrue(skill_entry.download_url.endswith("/v0.1.1.zip"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #30
Add method to install skill from URL (bypass search and most SkillEntry parsing)
Add helper method get_skill_entry_from_url to build a minimal SkillEntry from a github url
Add unit tests for added helper method