### PR TITLE
Fix skill installation from URL

### DIFF
--- a/ovos_skills_manager/github/utils.py
+++ b/ovos_skills_manager/github/utils.py
@@ -59,7 +59,7 @@ def normalize_github_url(url):
         .replace("https://api.github.com/repos/", "https://github.com/")\
         .replace(".git", "")
     if not url.startswith("https://github.com/"):
-        raise GithubInvalidUrl
+        raise GithubInvalidUrl(url)
     fields = url.replace("https://github.com/", "").split("/")
     author, skillname = fields[:2]
     if '@' in skillname:
@@ -70,12 +70,12 @@ def normalize_github_url(url):
 def blob2raw(url, validate=False):
     if not url.startswith("https://github.com") and \
             not url.startswith("https://raw.githubusercontent.com"):
-        raise GithubInvalidUrl
+        raise GithubInvalidUrl(url)
     url = url.replace("/blob", ""). \
         replace("https://github.com", "https://raw.githubusercontent.com")
     if validate:
         if requests.get(url).status_code != 200:
-            raise GithubRawUrlNotFound
+            raise GithubRawUrlNotFound(url)
     return url
 
 
@@ -133,7 +133,7 @@ def download_url_from_github_url(url, branch=None):
     if requests.get(url).status_code == 200:
         return url
 
-    raise GithubInvalidUrl
+    raise GithubInvalidUrl(url)
 
 
 def validate_github_skill_url(url, branch=None):
@@ -165,5 +165,5 @@ def match_url_template(url, template, branch=None):
         if "<title>Rate limit &middot; GitHub</title>" in requests.get(url).text:
             raise GithubHTTPRateLimited
         return blob2raw(url)
-    raise GithubInvalidUrl
+    raise GithubInvalidUrl(url)
 

--- a/ovos_skills_manager/github/utils.py
+++ b/ovos_skills_manager/github/utils.py
@@ -55,6 +55,7 @@ GITHUB_LOGO_FILES = ["ui/logo.png", "logo.png",
 # url utils
 def normalize_github_url(url):
     url = url\
+        .replace("git://", "https://")\
         .replace("https://raw.githubusercontent.com", "https://github.com")\
         .replace("https://api.github.com/repos/", "https://github.com/")\
         .replace(".git", "")

--- a/ovos_skills_manager/osm.py
+++ b/ovos_skills_manager/osm.py
@@ -287,7 +287,7 @@ class OVOSSkillsManager:
             requirements = merge_dict(requirements, json.get("requirements", {}),
                                       merge_lists=True, skip_empty=True, no_dupes=True)
         except GithubFileNotFound:
-            json = {"authorname": author_repo_from_github_url(url)}
+            json = {"authorname": author_repo_from_github_url(url)[0]}
         return SkillEntry.from_json({"url": url,
                                      "branch": branch,
                                      "requirements": requirements,

--- a/ovos_skills_manager/osm.py
+++ b/ovos_skills_manager/osm.py
@@ -268,8 +268,8 @@ class OVOSSkillsManager:
     def skill_entry_from_url(url: str):
         """
         Builds a minimal SkillEntry object from the passed GitHub URL to use for skill installation
-        :param url:
-        :return:
+        :param url: URL of skill to install
+        :return: SkillEntry object with url, branch, requirements, and authorname populated
         """
         from ovos_skills_manager.exceptions import GithubInvalidBranch, GithubFileNotFound
         from ovos_skills_manager.github import get_branch_from_github_url, normalize_github_url, get_requirements_json,\

--- a/ovos_skills_manager/skill_entry.py
+++ b/ovos_skills_manager/skill_entry.py
@@ -123,7 +123,7 @@ class SkillEntry:
 
     @property
     def skill_author(self):
-        return self.json.get("authorname") or self.url.split("/")[-2]
+        return self.json.get("authorname") or self.url.split("/")[-2] if self.url and "/" in self.url else ""
 
     @property
     def skill_tags(self):

--- a/ovos_skills_manager/skill_entry.py
+++ b/ovos_skills_manager/skill_entry.py
@@ -333,7 +333,7 @@ class SkillEntry:
 
     def __repr__(self):
         if not self.skill_name:
-            return self.url
+            return self.url or repr(self.json)
         return self.skill_name + " " + self.url
 
     def __eq__(self, other):

--- a/ovos_skills_manager/skill_entry.py
+++ b/ovos_skills_manager/skill_entry.py
@@ -110,7 +110,7 @@ class SkillEntry:
 
     @property
     def skill_folder(self):
-        return self.json.get("foldername") or self.url.split("/")[-1]
+        return self.json.get("foldername") or self.url.split("/")[-1] if self.url and "/" in self.url else ""
 
     @property
     def skill_category(self):

--- a/ovos_skills_manager/skill_entry.py
+++ b/ovos_skills_manager/skill_entry.py
@@ -325,11 +325,10 @@ class SkillEntry:
 
     def is_previously_installed(self, folder=None):
         folder = folder or get_skills_folder()
-        skill_dirname = self.uuid
-        if not skill_dirname:
-            raise SkillEntryError(f"OSM installation of {self.skill_name or 'unknown skill'} failed!"
-                                  f" uuid was not defined.")
-        return isdir(join(folder, skill_dirname))
+        # TODO If self.uuid is None, this skill entry is somehow malformed,
+        # probably because it was created manually with partial input.
+        # Something should happen in this case, but what?
+        return isdir(join(folder, self.uuid)) if self.uuid else False
 
     def __repr__(self):
         if not self.skill_name:

--- a/ovos_skills_manager/skill_entry.py
+++ b/ovos_skills_manager/skill_entry.py
@@ -34,7 +34,8 @@ class SkillEntry:
             return repo + "." + author
         except ValueError as e:
             LOG.error(e)
-            raise SkillEntryError(f"Could not build uuid for skill {self.skill_name}")
+            raise SkillEntryError(f"OSM installation of {self.skill_name or 'unknown skill'} failed!"
+                                  f" authorname or foldername not defined.")
 
     @property
     def json(self):

--- a/ovos_skills_manager/skill_entry.py
+++ b/ovos_skills_manager/skill_entry.py
@@ -32,9 +32,8 @@ class SkillEntry:
             author = self.skill_author.lower()
             repo = self.skill_folder.lower()
             return repo + "." + author
-        except Exception as e:
+        except ValueError as e:
             LOG.error(e)
-            LOG.error(f"author={self.skill_author} folder={self.skill_folder}")
             raise SkillEntryError(f"Could not build uuid for skill {self.skill_name}")
 
     @property
@@ -111,7 +110,10 @@ class SkillEntry:
 
     @property
     def skill_folder(self):
-        return self.json.get("foldername") or self.url.split("/")[-1]
+        folder = self.json.get("foldername") or self.url.split("/")[-1]
+        if not folder:
+            raise ValueError("foldername is not defined!")
+        return folder
 
     @property
     def skill_category(self):
@@ -124,7 +126,10 @@ class SkillEntry:
 
     @property
     def skill_author(self):
-        return self.json.get("authorname")
+        authorname = self.json.get("authorname")
+        if not authorname:
+            raise ValueError("authorname is not defined!")
+        return authorname
 
     @property
     def skill_tags(self):

--- a/ovos_skills_manager/skill_entry.py
+++ b/ovos_skills_manager/skill_entry.py
@@ -5,7 +5,7 @@ from os.path import isfile, expanduser, join, isdir
 
 from ovos_skills_manager.session import SESSION as requests
 from ovos_skills_manager.exceptions import GithubInvalidUrl, \
-    JSONDecodeError, GithubFileNotFound, GithubInvalidBranch
+    JSONDecodeError, GithubFileNotFound, GithubInvalidBranch, SkillEntryError
 from ovos_skills_manager.github import download_url_from_github_url, \
     get_branch, get_skill_data, get_requirements, get_branch_from_github_url
 from ovos_utils.json_helper import merge_dict
@@ -28,9 +28,14 @@ class SkillEntry:
         # a unique identifier
         # github_repo.github_author , case insensitive
         # should be guaranteed to be unique
-        author = self.skill_author.lower()
-        repo = self.skill_folder.lower()
-        return repo + "." + author
+        try:
+            author = self.skill_author.lower()
+            repo = self.skill_folder.lower()
+            return repo + "." + author
+        except Exception as e:
+            LOG.error(e)
+            LOG.error(f"author={self.skill_author} folder={self.skill_folder}")
+            raise SkillEntryError(f"Could not build uuid for skill {self.skill_name}")
 
     @property
     def json(self):

--- a/tests/test_osm.py
+++ b/tests/test_osm.py
@@ -38,6 +38,7 @@ class TestOvosSkillsManager(unittest.TestCase):
         self.assertIsInstance(skill_entry.requirements["skill"], list)
         self.assertIsInstance(skill_entry.download_url, str)
         self.assertTrue(skill_entry.download_url.endswith("/main.zip"))
+        self.assertIsInstance(skill_entry.uuid, str)
 
     def test_get_skill_entry_from_url_no_json(self):
         from ovos_skills_manager import SkillEntry
@@ -54,6 +55,7 @@ class TestOvosSkillsManager(unittest.TestCase):
         self.assertTrue(len(skill_entry.requirements["skill"]) > 0)
         self.assertIsInstance(skill_entry.download_url, str)
         self.assertTrue(skill_entry.download_url.endswith("/no_json.zip"))
+        self.assertIsInstance(skill_entry.uuid, str)
 
     def test_get_skill_entry_from_url_release(self):
         from ovos_skills_manager import SkillEntry
@@ -70,8 +72,9 @@ class TestOvosSkillsManager(unittest.TestCase):
         self.assertIsInstance(skill_entry.requirements["skill"], list)
         self.assertIsInstance(skill_entry.download_url, str)
         self.assertTrue(skill_entry.download_url.endswith("/v0.1.1.zip"))
+        self.assertIsInstance(skill_entry.uuid, str)
 
-    def test_install_skill_from_url(self):
+    def test_install_skill_from_url_valid(self):
         osm.install_skill_from_url("https://github.com/NeonDaniel/skill-osm-test@installable", TEST_INSTALL_DIR)
         self.assertTrue(os.path.isdir(os.path.join(TEST_INSTALL_DIR, "skill-osm-test.neondaniel")),
                         os.listdir(TEST_INSTALL_DIR))

--- a/tests/test_osm.py
+++ b/tests/test_osm.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import sys
 import unittest
 
@@ -7,6 +8,8 @@ from ovos_skills_manager.osm import OVOSSkillsManager
 from ovos_skills_manager.session import set_github_token
 osm = OVOSSkillsManager()
 
+TEST_INSTALL_DIR = os.path.join(os.path.dirname(__file__), "skills")
+
 
 class TestOvosSkillsManager(unittest.TestCase):
     @classmethod
@@ -14,6 +17,15 @@ class TestOvosSkillsManager(unittest.TestCase):
         github_token = os.environ.get("GITHUB_TOKEN")
         if github_token:
             set_github_token(github_token)
+
+    def setUp(self) -> None:
+        if os.path.exists(TEST_INSTALL_DIR):
+            shutil.rmtree(TEST_INSTALL_DIR)
+        os.makedirs(TEST_INSTALL_DIR)
+
+    def tearDown(self) -> None:
+        if os.path.exists(TEST_INSTALL_DIR):
+            shutil.rmtree(TEST_INSTALL_DIR)
 
     def test_get_skill_entry_from_url_default_branch(self):
         from ovos_skills_manager import SkillEntry
@@ -58,6 +70,12 @@ class TestOvosSkillsManager(unittest.TestCase):
         self.assertIsInstance(skill_entry.requirements["skill"], list)
         self.assertIsInstance(skill_entry.download_url, str)
         self.assertTrue(skill_entry.download_url.endswith("/v0.1.1.zip"))
+
+    def test_install_skill_from_url(self):
+        osm.install_skill_from_url("https://github.com/NeonDaniel/skill-osm-test@installable", TEST_INSTALL_DIR)
+        self.assertTrue(os.path.isdir(os.path.join(TEST_INSTALL_DIR, "skill-osm-test.neondaniel")),
+                        os.listdir(TEST_INSTALL_DIR))
+        self.assertTrue(os.path.isfile(os.path.join(TEST_INSTALL_DIR, "skill-osm-test.neondaniel", "__init__.py")))
 
 
 if __name__ == "__main__":

--- a/tests/test_skill_entry.py
+++ b/tests/test_skill_entry.py
@@ -110,6 +110,13 @@ class TestSkillEntry(unittest.TestCase):
         requirements = entry.json.pop("requirements")
         self.assertEqual(requirements, entry.requirements)
 
+    def test_skill_entry_properties_invalid_entry(self):
+        entry = SkillEntry({})
+        self.assertIsNone(entry.uuid)
+        self.assertIsInstance(entry.json, dict)
+        self.assertIsInstance(repr(entry), str)
+        self.assertEqual(entry, SkillEntry({}))
+
     # TODO: Find a good method for parsing versions in requirements; for now, requirements installer should handle
     #       compatible versions, this just needs to handle incompatible versions
     # def test_requirements_mismatch_versions(self):

--- a/tests/test_skill_entry.py
+++ b/tests/test_skill_entry.py
@@ -11,6 +11,7 @@ class TestSkillEntry(unittest.TestCase):
         entry = SkillEntry.from_github_url("https://github.com/NeonGeckoCom/speed-test.neon/tree/dev")
         self.assertIsInstance(entry.requirements, dict)
         self.assertIsInstance(entry.requirements["python"], list)
+        self.assertIsInstance(entry.uuid, str)
 
     def test_requirements_json_manifest_txt_dep_system_reqs(self):
         entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test/tree/v0.1")
@@ -27,6 +28,7 @@ class TestSkillEntry(unittest.TestCase):
 
         self.assertEqual(entry.branch, "v0.1")
         self.assertEqual(entry.download_url, "https://github.com/NeonDaniel/skill-osm-test/archive/v0.1.zip")
+        self.assertIsInstance(entry.uuid, str)
 
     def test_requirements_json_manifest_txt(self):
         entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test/tree/main")
@@ -44,6 +46,7 @@ class TestSkillEntry(unittest.TestCase):
 
         self.assertEqual(entry.branch, "main")
         self.assertEqual(entry.download_url, "https://github.com/NeonDaniel/skill-osm-test/archive/main.zip")
+        self.assertIsInstance(entry.uuid, str)
 
     def test_implicit_branch(self):
         entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test")
@@ -60,6 +63,7 @@ class TestSkillEntry(unittest.TestCase):
 
         self.assertEqual(entry.branch, "v0.1")
         self.assertEqual(entry.download_url, "https://github.com/NeonDaniel/skill-osm-test/archive/v0.1.zip")
+        self.assertIsInstance(entry.uuid, str)
 
     def test_explicit_branch(self):
         entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test@dev")
@@ -72,6 +76,7 @@ class TestSkillEntry(unittest.TestCase):
 
         self.assertEqual(entry.branch, "dev")
         self.assertEqual(entry.download_url, "https://github.com/NeonDaniel/skill-osm-test/archive/dev.zip")
+        self.assertIsInstance(entry.uuid, str)
 
     def test_equivalent_branch_specs(self):
         tree_spec = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test/tree/dev")

--- a/tests/test_skill_entry.py
+++ b/tests/test_skill_entry.py
@@ -11,7 +11,6 @@ class TestSkillEntry(unittest.TestCase):
         entry = SkillEntry.from_github_url("https://github.com/NeonGeckoCom/speed-test.neon/tree/dev")
         self.assertIsInstance(entry.requirements, dict)
         self.assertIsInstance(entry.requirements["python"], list)
-        self.assertIsInstance(entry.uuid, str)
 
     def test_requirements_json_manifest_txt_dep_system_reqs(self):
         entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test/tree/v0.1")
@@ -28,7 +27,6 @@ class TestSkillEntry(unittest.TestCase):
 
         self.assertEqual(entry.branch, "v0.1")
         self.assertEqual(entry.download_url, "https://github.com/NeonDaniel/skill-osm-test/archive/v0.1.zip")
-        self.assertIsInstance(entry.uuid, str)
 
     def test_requirements_json_manifest_txt(self):
         entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test/tree/main")
@@ -46,7 +44,6 @@ class TestSkillEntry(unittest.TestCase):
 
         self.assertEqual(entry.branch, "main")
         self.assertEqual(entry.download_url, "https://github.com/NeonDaniel/skill-osm-test/archive/main.zip")
-        self.assertIsInstance(entry.uuid, str)
 
     def test_implicit_branch(self):
         entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test")


### PR DESCRIPTION
Adds some bugfixes, logging, and unit tests to address issues encountered when trying to install skills from URLs.


## Changelog
Add authorname to SkillEntry generated in skill_entry_from_url
Add optional skill_dir param to install_skill_from_url
Add optional folder param to install_skill
Encapsulate and log errors in building SkillEntry.uuid
Add OSM test of install_skill_from_url
Add entry.uuid checks to TestSkillEntry
Add url to raised GithubInvalidUrl exceptions in utils.py