### PR TITLE
fix: git:// breaks OSM

### DIFF
--- a/ovos_skills_manager/github/utils.py
+++ b/ovos_skills_manager/github/utils.py
@@ -55,6 +55,7 @@ GITHUB_LOGO_FILES = ["ui/logo.png", "logo.png",
 # url utils
 def normalize_github_url(url):
     url = url\
+        .replace("git://", "https://")\
         .replace("https://raw.githubusercontent.com", "https://github.com")\
         .replace("https://api.github.com/repos/", "https://github.com/")\
         .replace(".git", "")


### PR DESCRIPTION
Adds `"git://"` to the chain of `.replace()` calls in the GitHub URL normalizer. This is a kludge, but I think it should cover 100% of cases, as I can think of no circumstances under which a repository can be installed as `git://github.com/foobar`, but not as `https://github.com/foobar`.