### PR TITLE
fix SkillEntry.generate_desktop_file() ConcatErr

### DIFF
--- a/ovos_skills_manager/skill_entry.py
+++ b/ovos_skills_manager/skill_entry.py
@@ -199,7 +199,8 @@ class SkillEntry:
 
         desktop_file = "[Desktop Entry]"
         for k in desktop_json:
-            desktop_file += "\n" + k + "=" + desktop_json[k]
+           if desktop_json[k]:
+                desktop_file += "\n" + k + "=" + desktop_json[k]
         return desktop_file
 
     def generate_readme(self):

--- a/ovos_skills_manager/skill_entry.py
+++ b/ovos_skills_manager/skill_entry.py
@@ -300,6 +300,8 @@ class SkillEntry:
 
         LOG.info("Downloading " + self.url)
         updated = self.download(folder)
+        # TODO: desktop file generation has been disabled for the time being
+        '''
         if self.json.get("desktopFile"):
             LOG.info("Creating desktop entry")
             # TODO support system wide? /usr/local/XXX ?
@@ -329,7 +331,7 @@ class SkillEntry:
             desktop_file = join(desktop_dir, base_name + ".desktop")
             with open(desktop_file, "w") as f:
                 f.write(self.desktop_file)
-
+            '''
         return updated
 
     def update(self, folder=None, default_branch="master", platform=None):


### PR DESCRIPTION
Fix: Because exceptions are raised, skill installation can fail or appear to fail when desktop entry creation is unsuccessful.