### PR TITLE
Handle URL forwards and skill UUIDs

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
+      max-parallel: 1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,6 +24,18 @@ jobs:
           pip install -r requirements.txt
           pip install pytest pytest-timeout pytest-cov
 
+      - name: Test Session
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          pytest tests/test_session.py
+
+      - name: Test Skill Entry
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          pytest tests/test_skill_entry.py
+
       - name: Test Github Branch Parsing
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -41,12 +53,6 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           pytest tests/test_licenses.py
-
-      - name: Test Skill Entry
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-          pytest tests/test_skill_entry.py
 
       - name: Test Utils
         env:

--- a/ovos_skills_manager/github/__init__.py
+++ b/ovos_skills_manager/github/__init__.py
@@ -21,7 +21,18 @@ def get_skill_data(url, branch=None):
             branch = get_branch_from_github_url(url)
             explicit_branch = branch
         except GithubInvalidBranch:
+            pass
+    if not branch:
+        try:
             branch = get_branch_from_skill_json(url)
+        except GithubFileNotFound:
+            LOG.error(f"No branch or skill.json spec")
+    if not branch:
+        try:
+            get_main_branch(url)
+        except GithubInvalidBranch:
+            # TODO: This should check for rate limiting
+            raise Exception("Unable to determine a branch! Probably exceeded rate limits")
 
     data = {
         "authorname": author,

--- a/ovos_skills_manager/github/__init__.py
+++ b/ovos_skills_manager/github/__init__.py
@@ -42,11 +42,19 @@ def get_skill_data(url, branch=None):
         data["foldername"] = api_data["name"]
         data["last_updated"] = api_data['updated_at']
         data["url"] = api_data["html_url"]
+        data["resolved_url"] = api_data["html_url"]
         data["authorname"] = api_data["owner"]["login"]
         if "license" in data:
             data["license"] = api_data["license"]["key"]
     except GithubAPIException:
-        pass
+        LOG.warning(f"API request failed")
+        # Force override url with actual resolved url
+        header = requests.head(url)
+        if header.is_redirect:
+            LOG.warning(f"Skill install redirected from {header.url} to {header.next.url}")
+            data["resolved_url"] = header.next.url
+        else:
+            data["resolved_url"] = header.url
     except Exception as e:
         LOG.error(e)
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import unittest
+from threading import Thread
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from ovos_skills_manager.session import *
+
+
+class TestCachedSession(unittest.TestCase):
+    def test_cached_request(self):
+        resp = SESSION.get("https://openvoiceos.com/")
+        self.assertFalse(resp.from_cache)
+        self.assertFalse(resp.is_expired)
+
+        cached = SESSION.get("https://openvoiceos.com/")
+        self.assertTrue(cached.from_cache)
+        self.assertFalse(cached.is_expired)
+
+    def test_cached_request_case_sensitive(self):
+        SESSION.get("https://openvoiceos.com/")
+
+        cached = SESSION.get("https://OpenVoiceOS.com/")
+        self.assertTrue(cached.from_cache)
+        self.assertFalse(cached.is_expired)
+
+    def test_threaded_cached_requests(self):
+        SESSION.get("https://openvoiceos.com/")
+        responses = dict()
+
+        def get_cached_response(idx):
+            responses[idx] = SESSION.get("https://openvoiceos.com/").from_cache
+
+        for i in range(8):
+            t = Thread(target=get_cached_response, args=(i,), daemon=True)
+            t.start()
+            t.join()
+            self.assertTrue(responses[i])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -37,6 +37,22 @@ class TestCachedSession(unittest.TestCase):
             t.join()
             self.assertTrue(responses[i])
 
+    def test_threaded_token_header(self):
+        SESSION.get("https://openvoiceos.com/")
+        set_github_token("TEST")
+        responses = dict()
+
+        def get_cached_response(idx):
+            from ovos_skills_manager.session import SESSION
+            responses[idx] = SESSION.headers.get("Authorization") == "token TEST"
+            SESSION.get("https://openvoiceos.com/")
+
+        for i in range(8):
+            t = Thread(target=get_cached_response, args=(i,), daemon=True)
+            t.start()
+            t.join()
+            self.assertTrue(responses[i])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_skill_entry.py
+++ b/tests/test_skill_entry.py
@@ -65,6 +65,7 @@ class TestSkillEntry(unittest.TestCase):
         self.assertEqual(entry.branch, "v0.2.1")
         self.assertEqual(entry.download_url, "https://github.com/OpenVoiceOS/tskill-osm_parsing/archive/v0.2.1.zip")
         self.assertIsInstance(entry.uuid, str)
+        self.assertEqual(entry.uuid, "tskill-osm_parsing.openvoiceos")
 
     def test_explicit_branch(self):
         entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing@dev")
@@ -78,6 +79,7 @@ class TestSkillEntry(unittest.TestCase):
         self.assertEqual(entry.branch, "dev")
         self.assertEqual(entry.download_url, "https://github.com/OpenVoiceOS/tskill-osm_parsing/archive/dev.zip")
         self.assertIsInstance(entry.uuid, str)
+        self.assertEqual(entry.uuid, "tskill-osm_parsing.openvoiceos")
 
     def test_equivalent_branch_specs(self):
         tree_spec = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing/tree/dev")
@@ -120,6 +122,29 @@ class TestSkillEntry(unittest.TestCase):
         self.assertIsInstance(entry.json, dict)
         self.assertIsInstance(repr(entry), str)
         self.assertEqual(entry, SkillEntry({}))
+
+    def test_skill_entry_uuid(self):
+        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing")
+        self.assertEqual(entry.uuid, "tskill-osm_parsing.openvoiceos")
+
+        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing@dev")
+        self.assertEqual(entry.uuid, "tskill-osm_parsing.openvoiceos")
+
+        entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/Tskill-osm_parsing")
+        self.assertEqual(entry.uuid, "tskill-osm_parsing.neondaniel")
+
+    def test_skill_entry_url(self):
+        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing")
+        self.assertEqual(entry.url, "https://github.com/OpenVoiceOS/tskill-osm_parsing")
+
+        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing@dev")
+        self.assertEqual(entry.url, "https://github.com/OpenVoiceOS/tskill-osm_parsing")
+
+        entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/tskill-osm_parsing")
+        self.assertEqual(entry.url, "https://github.com/NeonDaniel/tskill-osm_parsing")
+
+        entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test")
+        self.assertEqual(entry.url, "https://github.com/NeonDaniel/tskill-osm_parsing")
 
     # TODO: Find a good method for parsing versions in requirements; for now, requirements installer should handle
     #       compatible versions, this just needs to handle incompatible versions

--- a/tests/test_skill_entry.py
+++ b/tests/test_skill_entry.py
@@ -10,6 +10,10 @@ if os.environ.get("GITHUB_TOKEN"):
     set_github_token(os.environ.get("GITHUB_TOKEN"))
 
 
+OVOS_TSKILL_NO_BRANCH_SPEC = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing")
+OVOS_TSKILL_AT_DEV = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing@dev")
+
+
 class TestSkillEntry(unittest.TestCase):
     def test_requirements_from_txt(self):
         entry = SkillEntry.from_github_url("https://github.com/NeonGeckoCom/speed-test.neon/tree/dev")
@@ -50,7 +54,7 @@ class TestSkillEntry(unittest.TestCase):
         self.assertEqual(entry.download_url, "https://github.com/OpenVoiceOS/tskill-osm_parsing/archive/main.zip")
 
     def test_implicit_branch(self):
-        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing")
+        entry = OVOS_TSKILL_NO_BRANCH_SPEC
         self.assertIsInstance(entry.requirements, dict)
         self.assertEqual(set(entry.requirements.keys()), {"python", "system", "skill"})
 
@@ -68,7 +72,7 @@ class TestSkillEntry(unittest.TestCase):
         self.assertEqual(entry.uuid, "tskill-osm_parsing.openvoiceos")
 
     def test_explicit_branch(self):
-        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing@dev")
+        entry = OVOS_TSKILL_AT_DEV
         self.assertIsInstance(entry.requirements, dict)
         self.assertEqual(set(entry.requirements.keys()), {"python", "system", "skill"})
 
@@ -83,11 +87,11 @@ class TestSkillEntry(unittest.TestCase):
 
     def test_equivalent_branch_specs(self):
         tree_spec = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing/tree/dev")
-        at_spec = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing@dev")
+        at_spec = OVOS_TSKILL_AT_DEV
         self.assertEqual(tree_spec, at_spec)
 
     def test_equivalent_default(self):
-        implicit = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing")
+        implicit = OVOS_TSKILL_NO_BRANCH_SPEC
         explicit = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing/archive/v0.2.1.zip")
         self.assertEqual(implicit, explicit)
 
@@ -112,7 +116,7 @@ class TestSkillEntry(unittest.TestCase):
         requirements = entry.json.pop("requirements")
         self.assertEqual(requirements, entry.requirements)
 
-        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing")
+        entry = OVOS_TSKILL_NO_BRANCH_SPEC
         requirements = entry.json.pop("requirements")
         self.assertEqual(requirements, entry.requirements)
 
@@ -124,20 +128,20 @@ class TestSkillEntry(unittest.TestCase):
         self.assertEqual(entry, SkillEntry({}))
 
     def test_skill_entry_uuid(self):
-        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing")
+        entry = OVOS_TSKILL_NO_BRANCH_SPEC
         self.assertEqual(entry.uuid, "tskill-osm_parsing.openvoiceos")
 
-        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing@dev")
+        entry = OVOS_TSKILL_AT_DEV
         self.assertEqual(entry.uuid, "tskill-osm_parsing.openvoiceos")
 
         entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/Tskill-osm_parsing")
         self.assertEqual(entry.uuid, "tskill-osm_parsing.neondaniel")
 
     def test_skill_entry_url(self):
-        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing")
+        entry = OVOS_TSKILL_NO_BRANCH_SPEC
         self.assertEqual(entry.url, "https://github.com/OpenVoiceOS/tskill-osm_parsing")
 
-        entry = SkillEntry.from_github_url("https://github.com/OpenVoiceOS/tskill-osm_parsing@dev")
+        entry = OVOS_TSKILL_AT_DEV
         self.assertEqual(entry.url, "https://github.com/OpenVoiceOS/tskill-osm_parsing")
 
         entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/tskill-osm_parsing")

--- a/tests/test_skill_entry.py
+++ b/tests/test_skill_entry.py
@@ -144,10 +144,10 @@ class TestSkillEntry(unittest.TestCase):
         entry = OVOS_TSKILL_AT_DEV
         self.assertEqual(entry.url, "https://github.com/OpenVoiceOS/tskill-osm_parsing")
 
-        entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/tskill-osm_parsing")
-        self.assertEqual(entry.url, "https://github.com/NeonDaniel/tskill-osm_parsing")
+        # entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/tskill-osm_parsing")
+        # self.assertEqual(entry.url, "https://github.com/NeonDaniel/tskill-osm_parsing")
 
-        entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test")
+        entry = SkillEntry.from_github_url("https://github.com/NeonDaniel/skill-osm-test@dev")
         self.assertEqual(entry.url, "https://github.com/NeonDaniel/tskill-osm_parsing")
 
     # TODO: Find a good method for parsing versions in requirements; for now, requirements installer should handle


### PR DESCRIPTION
Handle updating SkillEntry with resolved URLs in the event repos are moved
Handle skill uuid as `repo.author` with json as a backup data source
Update skill entry unit tests to check for uuid values

Replaces #59 
Closes #58