### PR TITLE
Catch and handle missing optional skill files

### DIFF
--- a/ovos_skills_manager/github/__init__.py
+++ b/ovos_skills_manager/github/__init__.py
@@ -205,6 +205,8 @@ def get_requirements_json(url, branch=None):
     try:
         manif = get_manifest(url, branch)
         data = manif['dependencies'] or {}
+    except GithubFileNotFound:
+        LOG.debug("No manifest file available")
     except GithubSkillEntryError:
         LOG.error("Error reading from manifest!")
     data["python"] = data.get("python") or []
@@ -218,6 +220,8 @@ def get_requirements_json(url, branch=None):
     try:
         skill_req = get_skill_requirements(url, branch)
         data["skill"] = list(set(data["skill"] + skill_req))
+    except GithubFileNotFound:
+        LOG.debug("No skill requirements file available")
     except GithubSkillEntryError:
         LOG.error("Error reading skills requirements!")
     return data

--- a/ovos_skills_manager/github/__init__.py
+++ b/ovos_skills_manager/github/__init__.py
@@ -215,6 +215,8 @@ def get_requirements_json(url, branch=None):
     try:
         req = get_requirements(url, branch)
         data["python"] = list(set(data["python"] + req))
+    except GithubFileNotFound:
+        LOG.debug("No python requirements file available")
     except GithubSkillEntryError:
         LOG.error("Error reading from requirements files!")
     try:


### PR DESCRIPTION
Installing skills from git URLs will log errors if `manifest.yml` and `skill_requirements.txt` are missing, but most skills don't define these files. This PR handles these exceptions and logs to `debug` instead of `error`.