### PR TITLE
Add automation for publishing to PyPI

### DIFF
--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -1,0 +1,39 @@
+# This workflow will generate a distribution and upload it to PyPI
+
+name: Publish Alpha Build
+on:
+  push:
+    branches:
+      - dev
+    paths-ignore:
+      - 'ovos_skills_manager/versioning/osm_versions.py'
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install Build Tools
+        run: |
+          python -m pip install build wheel
+      - name: Increment Version
+        run: |
+          VER=$(python setup.py --version)
+          python version_bump.py
+      - name: Push Version Change
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Increment Version
+      - name: Build Distribution Packages
+        run: |
+          python setup.py bdist_wheel
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{secrets.PYPI_TOKEN}}

--- a/version_bump.py
+++ b/version_bump.py
@@ -1,0 +1,49 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+#
+# Copyright 2008-2021 Neongecko.com Inc. | All Rights Reserved
+#
+# Notice of License - Duplicating this Notice of License near the start of any file containing
+# a derivative of this software is a condition of license for this software.
+# Friendly Licensing:
+# No charge, open source royalty free use of the Neon AI software source and object is offered for
+# educational users, noncommercial enthusiasts, Public Benefit Corporations (and LLCs) and
+# Social Purpose Corporations (and LLCs). Developers can contact developers@neon.ai
+# For commercial licensing, distribution of derivative works or redistribution please contact licenses@neon.ai
+# Distributed on an "AS IS” basis without warranties or conditions of any kind, either express or implied.
+# Trademarks of Neongecko: Neon AI(TM), Neon Assist (TM), Neon Communicator(TM), Klat(TM)
+# Authors: Guy Daniels, Daniel McKnight, Regina Bloomstine, Elon Gasper, Richard Leeds
+#
+# Specialized conversational reconveyance options from Conversation Processing Intelligence Corp.
+# US Patents 2008-2021: US7424516, US20140161250, US20140177813, US8638908, US8068604, US8553852, US10530923, US10530924
+# China Patent: CN102017585  -  Europe Patent: EU2156652  -  Patents Pending
+
+import fileinput
+from os.path import join, dirname
+
+version_file = join(dirname(__file__), "ovos_skills_manager", "versioning",
+                    "osm_versions.py")
+version_var_name = "CURRENT_OSM_VERSION"
+
+with open(version_file, "r", encoding="utf-8") as v:
+    for line in v.readlines():
+        if line.startswith(version_var_name):
+            if '"' in line:
+                version = line.split('"')[1]
+            else:
+                version = line.split("'")[1]
+
+if "a" not in version:
+    parts = version.split('.')
+    parts[-1] = str(int(parts[-1]) + 1)
+    version = '.'.join(parts)
+    version = f"{version}a0"
+else:
+    post = version.split("a")[1]
+    new_post = int(post) + 1
+    version = version.replace(f"a{post}", f"a{new_post}")
+
+for line in fileinput.input(version_file, inplace=True):
+    if line.startswith(version_var_name):
+        print(f"{version_var_name} = \"{version}\"")
+    else:
+        print(line.rstrip('\n'))


### PR DESCRIPTION
This automates alpha versioning and publication to PyPI. A dev workflow would look like:

- create branch from `dev`
- make changes and open a PR to `dev` (probably not messing with `osm_versions.py`, though it is possible
- on PR merge to `dev`, version is incremented by `a1`
- when ready for release, create a PR that only changes version in `osm_versions.py` to desired version
- on merge into `dev`, version spec PR won't increment the version
- Release a non-alpha (this could be added to run on PR merge dev -> master, or on manual creation of release, etc)