### PR TITLE
Add non-interactive option to commandline install

### DIFF
--- a/ovos_skills_manager/commands.py
+++ b/ovos_skills_manager/commands.py
@@ -96,12 +96,14 @@ def enable(appstore):
                    'to 100 (exact match),  default 80')
 @click.option('--no-ignore-case', default=False, is_flag=True,
               help='ignore upper/lower case, default ignore')
+@click.option('--non-interactive', default=False, is_flag=True,
+              help='install single skill non-interactive from url and branch')
 def install(method, skill, fuzzy, no_ignore_case, thresh, appstore, search,
-            branch, folder):
+            branch, folder, non_interactive):
     if skill is None:
         skill = click.prompt('Skill to install (url or search term)')
     _install.install(method, skill, fuzzy, no_ignore_case, thresh, appstore, search,
-            branch, folder)
+            branch, folder, non_interactive)
 #endregion install
 
 #region priority

--- a/ovos_skills_manager/github/utils.py
+++ b/ovos_skills_manager/github/utils.py
@@ -54,6 +54,9 @@ GITHUB_LOGO_FILES = ["ui/logo.png", "logo.png",
 
 # url utils
 def normalize_github_url(url):
+    if "www.github.com" in url:
+        url = url.replace("www.github.com", "github.com")
+
     url = url\
         .replace("git://", "https://")\
         .replace("https://raw.githubusercontent.com", "https://github.com")\

--- a/ovos_skills_manager/scripts/install.py
+++ b/ovos_skills_manager/scripts/install.py
@@ -48,46 +48,49 @@ def search_skill(method: str, query: str, fuzzy: bool, no_ignore_case: bool, thr
 
 
 def install(method: str, skill: str, fuzzy: bool, no_ignore_case: bool, thresh: float, appstore: str, search: bool,
-            branch: str, folder: str):
-    if search:
-        skills = search_skill(method, skill, fuzzy, no_ignore_case,
-                              thresh, appstore)
-    elif not skill.startswith("http"):
-        click.confirm('{s} does not look like a valid skill url, do you '
-                      'want to enable search?'.format(s=skill),
-                      abort=True)
-        skills = search_skill(method, skill, fuzzy, no_ignore_case,
-                              thresh, appstore)
-    else:
-        skills = [SkillEntry.from_github_url(skill, branch)]
-
-    if not len(skills):
-        click.echo("NO RESULTS")
-    else:
-        # ask option
-        prompt = "\nSearch Results:\n    appstore - branch - url \n"
-        opts = {}
-        for s in skills:
-            idx = len(opts) + 1
-            prompt += str(idx) + " - " + s.appstore + " - " + s.branch + " " +\
-                      s.url + "\n"
-            opts[idx] = s
-        prompt += "0 - cancel installation\n"
-        def ask_selection():
-            click.echo(prompt)
-            value = click.prompt('Select an option', type=int)
-            if value < 0 or value > len(opts):
-                click.echo("Invalid choice")
-                return ask_selection()
-            return value
-
-        value = ask_selection()
-        if value == 0:
-            click.echo("Installation cancelled")
-            return
-        skill = opts[value]
-        skill_str = skill.branch + " " + skill.url
-        click.confirm('Do you want to install {s} ?'.format(s=skill_str),
-                      abort=True)
+            branch: str, folder: str, non_interactive: bool):
+    if non_interactive:
+        skill = SkillEntry.from_github_url(skill, branch)
         skill.install(folder)
+    else:
+        if search:
+            skills = search_skill(method, skill, fuzzy, no_ignore_case,
+                                thresh, appstore)
+        elif not skill.startswith("http"):
+            click.confirm('{s} does not look like a valid skill url, do you '
+                        'want to enable search?'.format(s=skill),
+                        abort=True)
+            skills = search_skill(method, skill, fuzzy, no_ignore_case,
+                                thresh, appstore)
+        else:
+            skills = [SkillEntry.from_github_url(skill, branch)]
 
+        if not len(skills):
+            click.echo("NO RESULTS")
+        else:
+            # ask option
+            prompt = "\nSearch Results:\n    appstore - branch - url \n"
+            opts = {}
+            for s in skills:
+                idx = len(opts) + 1
+                prompt += str(idx) + " - " + s.appstore + " - " + s.branch + " " +\
+                        s.url + "\n"
+                opts[idx] = s
+            prompt += "0 - cancel installation\n"
+            def ask_selection():
+                click.echo(prompt)
+                value = click.prompt('Select an option', type=int)
+                if value < 0 or value > len(opts):
+                    click.echo("Invalid choice")
+                    return ask_selection()
+                return value
+
+            value = ask_selection()
+            if value == 0:
+                click.echo("Installation cancelled")
+                return
+            skill = opts[value]
+            skill_str = skill.branch + " " + skill.url
+            click.confirm('Do you want to install {s} ?'.format(s=skill_str),
+                        abort=True)
+            skill.install(folder)


### PR DESCRIPTION
- Adds "--non-interactive" option to command line install options to install a single skill with branch without prompts, to be used by shell scripts and external applications
- Fix for GitHub URL normalization in GitHub utils for URLs containing "https://www.github.com" to normalize to "https://github.com", without this valid skill URLs starting with "www" do not work.