### PR TITLE
remove forcing log level info

### DIFF
--- a/ovos_skills_manager/__init__.py
+++ b/ovos_skills_manager/__init__.py
@@ -7,7 +7,5 @@ from ovos_skills_manager.appstores.neon import NeonSkills
 from ovos_skills_manager.appstores.local import InstalledSkills
 from ovos_skills_manager.osm import OVOSSkillsManager
 from ovos_skills_manager.upgrade_osm import do_launch_version_checks
-from ovos_utils.log import LOG
 
-LOG.set_level("INFO")
 do_launch_version_checks()


### PR DESCRIPTION
remove vestage from older non integrated days. A global log level of 'INFO' would be forced per OSM init.